### PR TITLE
Slack trustpilot app deny requests in threads

### DIFF
--- a/src/slackapp.js
+++ b/src/slackapp.js
@@ -69,6 +69,12 @@ function setupApp(slackapp, config, businessUnitProvider, trustpilot) {
     });
 
     slackapp.hears(["[1-5] stars?", "la(te)?st"], ["direct_mention"], (bot, message) => {
+        if (message.thread_ts) {
+            bot.reply(message, {
+                text: "Looks like we're in a thread? I'm confused! I can handle your request if you ask me in a channel."
+            });
+            return;
+        }
         var nbStars = Number(message.text.split(" ")[0]);
         nbStars = isNaN(nbStars) ? null : nbStars;
         var slackTeamId = bot.team_info.id;


### PR DESCRIPTION
Pull request opened by github-pullrequestcreator.
Trello: *[Slack-Trustpilot app: deny requests in threads](https://trello.com/c/efP05J0h/2761-slack-trustpilot-app-deny-requests-in-threads)*